### PR TITLE
Fix-playerdrop

### DIFF
--- a/bridge/server/esx.lua
+++ b/bridge/server/esx.lua
@@ -32,6 +32,7 @@ function setJailTime(src, time)
     if not playerState or not player then return end
 
     playerState.jailTime = time
+    playerState.xtprison_identifier = getCharID(src)
 
     return playerState and (playerState.jailTime == time) or false
 end exports('SetJailTime', setJailTime)

--- a/bridge/server/nd.lua
+++ b/bridge/server/nd.lua
@@ -34,6 +34,7 @@ function setJailTime(src, time)
     if not playerState or not player then return end
 
     playerState.jailTime = time
+    playerState.xtprison_identifier = getCharID(src)
 
     return playerState and (playerState.jailTime == time) or false
 end exports('SetJailTime', setJailTime)

--- a/bridge/server/ox.lua
+++ b/bridge/server/ox.lua
@@ -35,6 +35,7 @@ function setJailTime(src, time)
     if not playerState or not player then return end
 
     playerState.jailTime = time
+    playerState.xtprison_identifier = getCharID(src)
 
     return playerState and (playerState.jailTime == time) or false
 end exports('SetJailTime', setJailTime)

--- a/bridge/server/qb.lua
+++ b/bridge/server/qb.lua
@@ -34,6 +34,7 @@ function setJailTime(src, time)
     if not playerState or not player then return end
 
     playerState.jailTime = time
+    playerState.xtprison_identifier = getCharID(src)
     player.Functions.SetMetaData('injail', time)
     Wait(100)
 

--- a/bridge/server/qbx.lua
+++ b/bridge/server/qbx.lua
@@ -36,6 +36,7 @@ function setJailTime(src, time)
     if not playerState or not player then return end
 
     playerState.jailTime = time
+    playerState.xtprison_identifier = getCharID(src)
     player.Functions.SetMetaData('injail', time)
     Wait(100)
 

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -5,12 +5,12 @@ local utils             = require 'modules.server.utils'
 local ox_inventory      = exports.ox_inventory
 local globalState       = GlobalState
 
-local function savePlayerJailTime(src, cid)
-    cid = cid or getCharID(src)
+local function savePlayerJailTime(src)
     local state = Player(src).state
     local jailTime = state and state.jailTime or 0
-    local callback = MySQL.insert.await(db.UPDATE_JAILTIME, { cid, jailTime })
-    return callback
+    local cid = getCharID(src) or state and state.xtprison_identifier
+    if not cid then return lib.print.debug('player core identifier not found, not saving jailtime') end
+    MySQL.insert.await(db.UPDATE_JAILTIME, { cid, jailTime })
 end
 
 local function loadPlayerJailTime(src)
@@ -144,6 +144,5 @@ end)
 
 AddEventHandler('playerDropped', function(reason)
     local src = source
-    local cid = getCharID(src)
-    savePlayerJailTime(src, cid)
+    savePlayerJailTime(src)
 end)


### PR DESCRIPTION
Addresses issue with player citizen id being lost on drop by caching player citizen id in a statebag preventing issues with saving jail time on logout/drop