### PR TITLE
Ensure client side enterPrison calls server side syncJailCompatibility

### DIFF
--- a/modules/client/prison.lua
+++ b/modules/client/prison.lua
@@ -138,6 +138,11 @@ end
 
 -- Entering Prison --
 function prisonModules.enterPrison(setTime)
+    local setServerJailTime = lib.callback.await('xt-prison:server:setJailStatus', false, setTime)
+    if not setServerJailTime then
+        return false
+    end
+
     if config.RemoveJob then
         local removed = lib.callback.await('xt-prison:server:removeJob', false)
         if not removed then


### PR DESCRIPTION
The current issue with the enterPrison code path is it will never call the `syncJailCompatibility` on the server side. 

This will make sure it does.