### PR TITLE
ox_target detected as qb-target tweak

### DIFF
--- a/bridge/compat/resources.lua
+++ b/bridge/compat/resources.lua
@@ -4,5 +4,5 @@
 return {
     xt_prisonjobs = (GetResourceState('xt-prisonjobs') == 'started'),
     randol_medical = (GetResourceState('randol_medical') == 'started'),
-    qb_target = (GetResourceState('qb-target') == 'started'),
+    qb_target = (GetResourceState('qb-target') == 'started' and GetResourceState('ox_target') ~= 'started'),
 }


### PR DESCRIPTION
For old versions of ox_target that were providing for (qb-target with) these exports they would get an error when the min/max z on AddBoxZone was nil.

This resolves it by forcing the ox_target bridging to be used instead.

--Using outdated versions isn't the best to encourage but a large amount of users do use it because the compatibility.